### PR TITLE
Auto-deactivate on PHP versions below 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+  - '7.4'
 
 install: composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@
 language: php
 
 php:
-  - '7.0'
-  - '7.1'
   - '7.2'
   - '7.3'
-  - '7.4'
 
 install: composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+# Travis CI Configuration File
+
+# Tell Travis CI we're using PHP
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+
+install: composer install
+
+script:
+  - vendor/bin/phpcs .
+  - vendor/bin/phpunit ./tests/*

--- a/civil-footnotes.php
+++ b/civil-footnotes.php
@@ -15,20 +15,25 @@ if ( version_compare( phpversion(), '7.0.0', '<' ) ) {
 			$php_version_warning = sprintf(
 				/* translators: Error message explaining PHP version is too low. %s: Current PHP version. */
 				__( 'Civil Footnotes requires PHP 7 or higher; you are using %s. Please contact your host to upgrade your PHP version, or downgrade to Civil Footnotes version 1.3.1.' ),
-				phversion()
+				phpversion()
 			);
 			$deactivation_notice = __( 'The plugin has been deactivated.', 'civil-footnotes' );
 
 			?>
 		<div class="notice notice-error is-dismissible">
-			<p><?php esc_html( $php_version_warning ); ?></p>
-			<p><?php esc_html( $deactivation_notice ); ?></p>
+			<p><?php echo esc_html( $php_version_warning ); ?></p>
+			<p><?php echo esc_html( $deactivation_notice ); ?></p>
 		</div>
 			<?php
 		}
 	);
 
-	deactivate_plugins( plugin_basename( __FILE__ ) );
+	add_action(
+		'admin_init',
+		function() {
+			deactivate_plugins( plugin_basename( __FILE__ ) );
+		}
+	);
 
 	// Halt plugin initialization.
 	return;

--- a/civil-footnotes.php
+++ b/civil-footnotes.php
@@ -9,21 +9,24 @@ Author: <a href="https://defomicron.net/colophon">Austin Sweeney</a>
 
 // We only support PHP 7 and up.
 if ( version_compare( phpversion(), '7.0.0', '<' ) ) {
-	add_action( 'admin_notices', function() {
-		/* translators: Error message explaining PHP version is too low. %s: Current PHP version. */
-		$php_version_warning = sprintf(
-			__( 'Civil Footnotes requires PHP 7 or higher; you are using %s. Please contact your host to upgrade your PHP version, or downgrade to Civil Footnotes version 1.3.1.' ),
-			phversion()
-		);
-		$deactivation_notice = __( 'The plugin has been deactivated.', 'civil-footnotes' );
+	add_action(
+		'admin_notices',
+		function() {
+			$php_version_warning = sprintf(
+				/* translators: Error message explaining PHP version is too low. %s: Current PHP version. */
+				__( 'Civil Footnotes requires PHP 7 or higher; you are using %s. Please contact your host to upgrade your PHP version, or downgrade to Civil Footnotes version 1.3.1.' ),
+				phversion()
+			);
+			$deactivation_notice = __( 'The plugin has been deactivated.', 'civil-footnotes' );
 
-		?>
+			?>
 		<div class="notice notice-error is-dismissible">
 			<p><?php esc_html( $php_version_warning ); ?></p>
 			<p><?php esc_html( $deactivation_notice ); ?></p>
 		</div>
-		<?php
-	} );
+			<?php
+		}
+	);
 
 	deactivate_plugins( plugin_basename( __FILE__ ) );
 

--- a/civil-footnotes.php
+++ b/civil-footnotes.php
@@ -7,7 +7,30 @@ Description: Parses and displays footnotes. Based on <a href="http://elvery.net/
 Author: <a href="https://defomicron.net/colophon">Austin Sweeney</a>
 */
 
-// Some important constants
+// We only support PHP 7 and up.
+if ( version_compare( phpversion(), '7.0.0', '<' ) ) {
+	add_action( 'admin_notices', function() {
+		/* translators: Error message explaining PHP version is too low. %s: Current PHP version. */
+		$php_version_warning = sprintf(
+			__( 'Civil Footnotes requires PHP 7 or higher; you are using %s. Please contact your host to upgrade your PHP version, or downgrade to Civil Footnotes version 1.3.1.' ),
+			phversion()
+		);
+		$deactivation_notice = __( 'The plugin has been deactivated.', 'civil-footnotes' );
+
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html( $php_version_warning ); ?></p>
+			<p><?php esc_html( $deactivation_notice ); ?></p>
+		</div>
+		<?php
+	} );
+
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+
+	// Halt plugin initialization.
+	return;
+}
+
 define( 'CIVIL_FOOTNOTES_VERSION', '1.3.1' );
 
 require_once plugin_dir_path( __FILE__ ) . 'inc/namespace.php';

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f037910d85409987cd01791adac2261",
+    "content-hash": "3f9984cd62e9ba12862169bbd1e5adc8",
     "packages": [
         {
             "name": "composer/installers",
@@ -125,6 +125,115 @@
                 "zikula"
             ],
             "time": "2018-08-27T06:10:37+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9999344e47e7af6b00e1a898eacc4e4368fb7196",
+                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-09-05T18:36:49+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-04-10T23:49:02+00:00"
         }
     ],
     "packages-dev": [
@@ -336,18 +445,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -383,80 +492,22 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Library for handling version information and constraints",
             "time": "2018-07-08T19:19:57+00:00"
-        },
-        {
-            "name": "phpcompatibility/php-compatibility",
-            "version": "9.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
-                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
-                },
-                {
-                    "name": "Wim Godden",
-                    "role": "lead",
-                    "homepage": "https://github.com/wimg"
-                },
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "role": "lead",
-                    "homepage": "https://github.com/jrfnl"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "time": "2019-06-27T19:58:56+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -823,8 +874,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -874,8 +925,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -916,8 +967,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Simple template engine.",
@@ -965,8 +1016,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -1095,8 +1146,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -1672,8 +1723,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
@@ -1715,64 +1766,13 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
-        },
-        {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
-            ],
-            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
This was a suggestion from Mika on the WP plugins team, that we can support only PHP 7 and up but that it would be best to give users a warning if they attempt to use the latest version of the plugin on older versions of PHP.